### PR TITLE
Refactor request types out of the exported types module.

### DIFF
--- a/roboto/__init__.py
+++ b/roboto/__init__.py
@@ -1,10 +1,10 @@
 # pylint: skip-file
 # flake8: noqa
 
+from .api_types import *
 from .bot import *
-from .types import *
 
 __all__ = [
-    *types.__all__,  # type: ignore
+    *api_types.__all__,  # type: ignore
     *bot.__all__,  # type: ignore
 ]

--- a/roboto/api_types.py
+++ b/roboto/api_types.py
@@ -44,16 +44,6 @@ class BotUser(_UserOptionalCommon, _BotUserRequired):
 
 
 @dataclass(frozen=True)
-class APIResponse:
-    """API Response format."""
-
-    ok: bool
-    result: Optional[Any] = None
-    error_code: Optional[int] = None
-    description: Optional[str] = None
-
-
-@dataclass(frozen=True)
 class ChatPhoto:
     """Information for fetching the chat picture."""
 
@@ -532,31 +522,7 @@ ReplyMarkup = Union[
 ]
 
 
-@dataclass(frozen=True)
-class SendMessageRequest:
-    """Parameters for sending a message."""
-
-    chat_id: Union[ChatID, str]
-    text: str
-    parse_mode: Optional[ParseMode] = None
-    disable_web_page_preview: Optional[bool] = None
-    disable_notification: Optional[bool] = None
-    reply_to_message_id: Optional[MessageID] = None
-    reply_markup: Optional[ReplyMarkup] = None
-
-
-@dataclass(frozen=True)
-class GetUpdatesRequest:
-    """Parameters for getting updates for a bot."""
-
-    offset: Optional[int] = None
-    limit: Optional[int] = None
-    timeout: Optional[int] = None
-    allowed_updates: Optional[List[str]] = None
-
-
 __all__ = [
-    'APIResponse',
     'Animation',
     'Audio',
     'BotUser',
@@ -569,7 +535,6 @@ __all__ = [
     'Document',
     'FileID',
     'Game',
-    'GetUpdatesRequest',
     'InlineQuery',
     'Invoice',
     'Location',
@@ -582,7 +547,6 @@ __all__ = [
     'ParseMode',
     'PhotoSize',
     'PreCheckoutQuery',
-    'SendMessageRequest',
     'ShippingAddress',
     'ShippingQuery',
     'Sticker',

--- a/roboto/api_types.py
+++ b/roboto/api_types.py
@@ -430,7 +430,7 @@ class Update:
 
 
 class ParseMode(Enum):
-    """Parse mode for text messages."""
+    """Parse mode for applying markup to text messages."""
 
     MARKDOWN = 'Markdown'
     HTML = 'HTML'

--- a/roboto/bot.py
+++ b/roboto/bot.py
@@ -108,6 +108,17 @@ class BotAPI:
         Args:
             chat_id: The ID of the chat to send a message to.
             text: The message text.
+            parse_mode: How to parse the text (see `ParseMode`). Parses as
+                        plain text if omitted.
+            disable_web_page_preview: Avoid showing previews for links.
+            disable_notification: Do not notify users that the message was sent.
+            reply_to_message_id: ID of a message that the sent message should
+                                 be a reply to.
+            reply_markup: Markup for offering an interface for the user to
+                          reply to the bot.
+
+        Returns:
+            The Message object for the message that was sent.
         """
         request = SendMessageRequest(
             chat_id,

--- a/roboto/bot.py
+++ b/roboto/bot.py
@@ -5,20 +5,19 @@ from typing import List, Optional, Union
 
 from asks import Session
 
-from .datautil import from_json
-from .http_api import HTTPMethod, make_request
-from .types import (
+from .api_types import (
     BotUser,
     ChatID,
-    GetUpdatesRequest,
     Message,
     MessageID,
     ParseMode,
     ReplyMarkup,
-    SendMessageRequest,
     Token,
     Update,
 )
+from .datautil import from_json
+from .http_api import HTTPMethod, make_request
+from .request_types import GetUpdatesRequest, SendMessageRequest
 from .url import URL
 
 TELEGRAM_BOT_API_URL = URL.make('https://api.telegram.org')

--- a/roboto/http_api.py
+++ b/roboto/http_api.py
@@ -1,12 +1,22 @@
 """Bot API request function."""
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 from asks import Session
 
 from .datautil import from_json, to_json
 from .error import BotAPIError
-from .types import APIResponse
+
+
+@dataclass(frozen=True)
+class APIResponse:
+    """API Response format."""
+
+    ok: bool
+    result: Optional[Any] = None
+    error_code: Optional[int] = None
+    description: Optional[str] = None
 
 
 class HTTPMethod(Enum):

--- a/roboto/request_types.py
+++ b/roboto/request_types.py
@@ -1,0 +1,28 @@
+"""Types representing the bodies of API requests."""
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from .api_types import ChatID, MessageID, ParseMode, ReplyMarkup
+
+
+@dataclass(frozen=True)
+class SendMessageRequest:
+    """Parameters for sending a message."""
+
+    chat_id: Union[ChatID, str]
+    text: str
+    parse_mode: Optional[ParseMode] = None
+    disable_web_page_preview: Optional[bool] = None
+    disable_notification: Optional[bool] = None
+    reply_to_message_id: Optional[MessageID] = None
+    reply_markup: Optional[ReplyMarkup] = None
+
+
+@dataclass(frozen=True)
+class GetUpdatesRequest:
+    """Parameters for getting updates for a bot."""
+
+    offset: Optional[int] = None
+    limit: Optional[int] = None
+    timeout: Optional[int] = None
+    allowed_updates: Optional[List[str]] = None

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -2,8 +2,7 @@
 import pytest
 
 from roboto.error import BotAPIError
-from roboto.http_api import validate_response
-from roboto.types import APIResponse
+from roboto.http_api import APIResponse, validate_response
 
 
 def test_validate_response() -> None:


### PR DESCRIPTION
- Separate types representing the body of HTTP API requests from vocabulary types that are used in roboto's own API.
- Avoid naming inner modules with generic names such as `types`.