### PR TITLE
Implement send_dice.

### DIFF
--- a/roboto/api_types.py
+++ b/roboto/api_types.py
@@ -356,6 +356,13 @@ class Poll:
     close_date: Optional[int] = None
 
 
+class DiceEmoji(Enum):
+    """Supported emojis for sending Dice messages."""
+
+    DICE = '🎲'
+    DART = '🎯'
+
+
 @dataclass(frozen=True)
 class Dice:
     """Representation of a Dice"""
@@ -853,6 +860,7 @@ __all__ = [
     'ChosenInlineResult',
     'Contact',
     'Dice',
+    'DiceEmoji',
     'Document',
     'EncryptedCredentials',
     'EncryptedPassportElement',

--- a/roboto/bot.py
+++ b/roboto/bot.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 from .api_types import (
     BotUser,
     ChatID,
+    DiceEmoji,
     InlineKeyboardMarkup,
     InlineMessageID,
     InputFile,
@@ -37,6 +38,7 @@ from .request_types import (
     SendAnimationRequest,
     SendAudioRequest,
     SendContactRequest,
+    SendDiceRequest,
     SendDocumentRequest,
     SendLocationRequest,
     SendMediaGroupRequest,
@@ -918,6 +920,38 @@ class BotAPI:
         return from_json(
             Poll,
             await make_request(self.session, HTTPMethod.POST, '/stopPoll', request),
+        )
+
+    async def send_dice(
+        self,
+        chat_id: Union[ChatID, str],
+        emoji: Optional[DiceEmoji] = None,
+        disable_notification: Optional[bool] = None,
+        reply_to_message_id: Optional[MessageID] = None,
+        reply_markup: Optional[ReplyMarkup] = None,
+    ) -> Message:
+        """sendDice API method.
+
+        Args:
+            chat_id: The ID of the chat to send a phone contact to.
+            emoji: The emoji to use in the Dice message. See `DiceEmoji`.
+            disable_notification: Do not notify users that the message was sent.
+            reply_to_message_id: ID of a message that the sent message should
+                                 be a reply to.
+            reply_markup: Markup for additional interface options for replying.
+        """
+
+        request = SendDiceRequest(
+            chat_id,
+            emoji,
+            disable_notification,
+            reply_to_message_id,
+            maybe_json_serialize(reply_markup),
+        )
+
+        return from_json(
+            Message,
+            await make_request(self.session, HTTPMethod.POST, '/sendDice', request),
         )
 
 

--- a/roboto/request_types.py
+++ b/roboto/request_types.py
@@ -5,6 +5,7 @@ from typing import Generic, List, Optional, TypeVar, Union, cast
 
 from .api_types import (
     ChatID,
+    DiceEmoji,
     InlineKeyboardMarkup,
     InlineMessageID,
     InputFile,
@@ -296,3 +297,14 @@ class StopPollRequest:
     chat_id: Union[ChatID, str]
     message_id: MessageID
     reply_markup: Optional[JSONSerialized[InlineKeyboardMarkup]] = None
+
+
+@dataclass(frozen=True)
+class SendDiceRequest:
+    """Parameters for requesting a Dice."""
+
+    chat_id: Union[ChatID, str]
+    emoji: Optional[DiceEmoji] = None
+    disable_notification: Optional[bool] = None
+    reply_to_message_id: Optional[MessageID] = None
+    reply_markup: Optional[JSONSerialized[ReplyMarkup]] = None

--- a/roboto/request_types.py
+++ b/roboto/request_types.py
@@ -301,7 +301,7 @@ class StopPollRequest:
 
 @dataclass(frozen=True)
 class SendDiceRequest:
-    """Parameters for requesting a Dice."""
+    """Parameters for sending a Dice."""
 
     chat_id: Union[ChatID, str]
     emoji: Optional[DiceEmoji] = None

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -10,6 +10,8 @@ from roboto import (
     BotUser,
     Chat,
     ChatID,
+    Dice,
+    DiceEmoji,
     FileDescription,
     InlineMessageID,
     InputMediaPhoto,
@@ -998,4 +1000,38 @@ async def test_stop_poll(mocked_bot_api: MockedBotAPI):
         explanation_entities=None,
         open_period=None,
         close_date=None,
+    )
+
+
+@pytest.mark.trio
+async def test_send_dice(mocked_bot_api: MockedBotAPI):
+    """Test that BotAPI.send_poll creates the correct payload and properly reads
+    back the returned message.
+    """
+
+    mocked_bot_api.response.json.return_value = {
+        'ok': True,
+        'result': {
+            'message_id': 1,
+            'date': 0,
+            'chat': {'id': 1, 'type': 'private'},
+            'from': {'id': 1, 'is_bot': True, 'first_name': 'Test'},
+            'dice': {'emoji': '🎯', 'value': 6},
+        },
+    }
+
+    message = await mocked_bot_api.api.send_dice(
+        chat_id=ChatID(1), emoji=DiceEmoji.DART
+    )
+
+    mocked_bot_api.request.assert_called_with(
+        'post', path='/sendDice', json={'chat_id': 1, 'emoji': '🎯'}
+    )
+
+    assert message == Message(
+        message_id=MessageID(1),
+        date=0,
+        chat=Chat(id=ChatID(1), type='private'),
+        from_=User(id=UserID(1), is_bot=True, first_name='Test'),
+        dice=Dice(emoji='🎯', value=6),
     )


### PR DESCRIPTION
Two things I am a bit concerned about this PR are:
1- I couldn't confirm if the representation of the dice emoji is really ":dice:"
2- I don't know if my implementation of default args for emoji is correct:
    - The DiceRequest class and the send_dice method both have a default ":dice:" which I don't know if it is redundant or not
    - The Dice class doesn't have a default argument
    Both of these seem to be implemented as the API documentation recommends. But it still sounds weird