### PR TITLE
Overhaul datautil

### DIFF
--- a/roboto/bot.py
+++ b/roboto/bot.py
@@ -25,7 +25,7 @@ from .api_types import (
     UserProfilePhotos,
 )
 from .asks import Session
-from .datautil import from_json
+from .datautil import from_json_like
 from .http_api import (
     HTTPMethod,
     make_multipart_request,
@@ -106,7 +106,7 @@ class BotAPI:
         Returns:
             User: the user object representing the bot itself.
         """
-        return from_json(
+        return from_json_like(
             BotUser, await make_request(self.session, HTTPMethod.GET, '/getMe')
         )
 
@@ -130,7 +130,7 @@ class BotAPI:
         """
         request = GetUpdatesRequest(offset, limit, timeout, allowed_updates)
 
-        return from_json(
+        return from_json_like(
             List[Update],
             await make_request(self.session, HTTPMethod.GET, '/getUpdates', request),
         )
@@ -172,7 +172,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendMessage', request),
         )
@@ -200,7 +200,7 @@ class BotAPI:
             chat_id, from_chat_id, message_id, disable_notification,
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(
                 self.session, HTTPMethod.POST, '/forwardMessage', request
@@ -243,7 +243,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message, await make_multipart_request(self.session, '/sendPhoto', request),
         )
 
@@ -298,7 +298,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message, await make_multipart_request(self.session, '/sendAudio', request),
         )
 
@@ -344,7 +344,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_multipart_request(self.session, '/sendDocument', request),
         )
@@ -403,7 +403,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message, await make_multipart_request(self.session, '/sendVideo', request),
         )
 
@@ -458,7 +458,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_multipart_request(self.session, '/sendAnimation', request),
         )
@@ -505,7 +505,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message, await make_multipart_request(self.session, '/sendVoice', request),
         )
 
@@ -550,7 +550,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_multipart_request(self.session, '/sendVideoNote', request),
         )
@@ -579,7 +579,7 @@ class BotAPI:
             chat_id, json_serialize(media), disable_notification, reply_to_message_id,
         )
 
-        return from_json(
+        return from_json_like(
             List[Message],
             await make_multipart_request_with_attachments(
                 self.session, '/sendMediaGroup', request, attachments
@@ -619,7 +619,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendLocation', request),
         )
@@ -654,7 +654,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(
                 self.session, HTTPMethod.POST, '/editMessageLiveLocation', request
@@ -685,7 +685,7 @@ class BotAPI:
             inline_message_id, latitude, longitude, maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(
                 self.session, HTTPMethod.POST, '/editMessageLiveLocation', request
@@ -714,7 +714,7 @@ class BotAPI:
             chat_id, message_id, maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(
                 self.session, HTTPMethod.POST, '/stopMessageLiveLocation', request
@@ -741,7 +741,7 @@ class BotAPI:
             inline_message_id, maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(
                 self.session, HTTPMethod.POST, '/stopMessageLiveLocation', request
@@ -790,7 +790,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendVenue', request),
         )
@@ -831,7 +831,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendContact', request),
         )
@@ -899,7 +899,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendPoll', request),
         )
@@ -922,7 +922,7 @@ class BotAPI:
             chat_id, message_id, maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Poll,
             await make_request(self.session, HTTPMethod.POST, '/stopPoll', request),
         )
@@ -954,7 +954,7 @@ class BotAPI:
             maybe_json_serialize(reply_markup),
         )
 
-        return from_json(
+        return from_json_like(
             Message,
             await make_request(self.session, HTTPMethod.POST, '/sendDice', request),
         )
@@ -971,7 +971,7 @@ class BotAPI:
 
         request = SendChatActionRequest(chat_id, action)
 
-        return from_json(
+        return from_json_like(
             bool,
             await make_request(
                 self.session, HTTPMethod.POST, '/sendChatAction', request
@@ -995,7 +995,7 @@ class BotAPI:
 
         request = GetUserProfilePhotosRequest(user_id, offset, limit)
 
-        return from_json(
+        return from_json_like(
             UserProfilePhotos,
             await make_request(
                 self.session, HTTPMethod.POST, '/getUserProfilePhotos', request

--- a/roboto/datautil.py
+++ b/roboto/datautil.py
@@ -122,7 +122,7 @@ def _from_json_like(type_hint, value):
 
 @overload
 def from_json_like(
-    tp: Type[List[T]], value: List[Any], optional: Literal[True],
+    tp: Type[List[T]], value: List[JSONLike], optional: Literal[True],
 ) -> Optional[List[T]]:  # pragma: no cover
     """Overload for from_json_like, refer to implementation."""
     ...
@@ -130,7 +130,7 @@ def from_json_like(
 
 @overload
 def from_json_like(
-    tp: Type[T], value: Any, optional: Literal[True],
+    tp: Type[T], value: JSONLike, optional: Literal[True],
 ) -> Optional[T]:  # pragma: no cover
     """Overload for from_json_like, refer to implementation."""
     ...
@@ -138,7 +138,7 @@ def from_json_like(
 
 @overload
 def from_json_like(
-    tp: Type[List[T]], value: List[Any], optional: Literal[False] = False,
+    tp: Type[List[T]], value: List[JSONLike], optional: Literal[False] = False,
 ) -> List[T]:  # pragma: no cover
     """Overload for from_json_like, refer to implementation."""
     ...
@@ -146,7 +146,7 @@ def from_json_like(
 
 @overload
 def from_json_like(
-    tp: Type[T], value: Any, optional: Literal[False] = False,
+    tp: Type[T], value: JSONLike, optional: Literal[False] = False,
 ) -> T:  # pragma: no cover
     """Overload for from_json_like, refer to implementation."""
     ...

--- a/roboto/datautil.py
+++ b/roboto/datautil.py
@@ -1,5 +1,5 @@
 """Utilities from deserializing values as dataclasses."""
-from dataclasses import Field, asdict, fields, is_dataclass
+from dataclasses import asdict, fields, is_dataclass
 from enum import Enum
 from typing import (
     Any,
@@ -14,7 +14,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Protocol
+from typing_extensions import Literal
 from typing_inspect import get_args, get_origin, is_optional_type
 
 from .error import RobotoError
@@ -22,15 +22,8 @@ from .typing_util import is_new_type, is_none_type, original_type, type_name
 
 T = TypeVar('T')
 
-Number = Union[int, float]
-JSONPrimitives = Optional[Union[Number, str, bool]]
+JSONPrimitives = Optional[Union[int, float, str, bool]]
 JSONLike = Union[JSONPrimitives, Dict[str, Any], List[Any]]
-
-
-class Dataclass(Protocol):
-    """Protocol for a dataclass instance or type."""
-
-    __dataclass_fields__: Dict[str, Field]
 
 
 def renames(cls: Type[T]) -> Dict[str, str]:
@@ -52,43 +45,27 @@ def renames(cls: Type[T]) -> Dict[str, str]:
     }
 
 
-def field_type(cls: Type[T], field_name: str) -> type:
-    """Get the type of a field from a dataclass.
-
-    `cls` is expected to be a dataclass type.
-
-    Args:
-        cls: A dataclass type.
-        field_name: The name of the field to query the type of.
-
-    Returns:
-        The type of the requested field.
-    """
-
-    return get_type_hints(cls)[field_name]
-
-
-def from_list(list_type: Type[List[T]], v: List[JSONLike]) -> List[T]:
+def from_list(tp: Type[List[T]], v: List[Any]) -> List[T]:
     """Transform a list of JSON-like structures into JSON-compatible objects."""
-    (inner_type,) = get_args(list_type)
-    return [from_json(inner_type, value) for value in v]
+    (inner_type,) = get_args(tp)
+    return [_from_json_like(inner_type, value) for value in v]
 
 
-def from_dict(cls: Type[T], d: Dict[str, JSONLike]):
+def from_dict(tp: Type[T], v: Dict[str, Any]) -> T:
     """Transform a JSON-like structure into a JSON-compatible dataclass."""
-    field_renames = renames(cls)
+    field_renames = renames(tp)
 
-    as_dataclass = cast(Dataclass, cls)
+    type_hints = get_type_hints(tp)
 
     for k in field_renames:
-        if k in d:
-            d[field_renames[k]] = d.pop(k)
+        if k in v:
+            v[field_renames[k]] = v.pop(k)
 
-    return cls(  # type: ignore
+    return tp(  # type: ignore
         **{
-            k: from_json(field_type(cls, k), v)
-            for k, v in d.items()
-            if k in as_dataclass.__dataclass_fields__
+            field_name: _from_json_like(type_hints[field_name], value)
+            for field_name, value in v.items()
+            if field_name in type_hints
         }
     )
 
@@ -102,115 +79,115 @@ class JSONConversionError(RobotoError):
         self.value = value
 
 
-@overload
-def from_json(schema_class: Type[List[T]], j: JSONLike) -> List[T]:
-    """Overload declaration of from_json."""
-    ...  # pragma: no cover
+def convert_single(tp: Type[T], v: Any) -> T:
+    """Convert a value into a single (non-list) type."""
+    if tp in (int, float):
+        if not isinstance(v, (int, float)):
+            raise JSONConversionError(f'Cannot read value {v} as a number.', tp, v)
+
+        return tp(v)  # type: ignore
+
+    if is_dataclass(tp):
+        if not isinstance(v, dict):
+            raise JSONConversionError(
+                f'Cannot read non-dict {v} as dataclass type {tp}.', tp, v,
+            )
+
+        return from_dict(tp, v)
+
+    real_type = tp if not is_new_type(tp) else original_type(tp)
+
+    if not isinstance(v, real_type):
+        raise JSONConversionError(
+            f'Cannot find any way to read value {v} as {tp}.', tp, v
+        )
+
+    return cast(T, v)
+
+
+def _from_json_like(type_hint, value):
+    optional = is_optional_type(type_hint)
+
+    (real_type,) = (
+        (t for t in get_args(type_hint) if not is_none_type(t))
+        if optional
+        else (type_hint,)
+    )
+
+    if real_type is Any:
+        return value
+
+    return from_json_like(real_type, value, optional)
 
 
 @overload
-def from_json(schema_class: Type[T], j: JSONLike) -> T:
-    """Overload declaration of from_json."""
-    ...  # pragma: no cover
+def from_json_like(
+    tp: Type[List[T]], value: List[Any], optional: Literal[True],
+) -> Optional[List[T]]:  # pragma: no cover
+    """Overload for from_json_like, refer to implementation."""
+    ...
 
 
 @overload
-def from_json(schema_class: None, j: JSONLike) -> None:
-    """Overload declaration of from_json."""
-    ...  # pragma: no cover
+def from_json_like(
+    tp: Type[T], value: Any, optional: Literal[True],
+) -> Optional[T]:  # pragma: no cover
+    """Overload for from_json_like, refer to implementation."""
+    ...
 
 
-def from_json(schema_class, j):
+@overload
+def from_json_like(
+    tp: Type[List[T]], value: List[Any], optional: Literal[False] = False,
+) -> List[T]:  # pragma: no cover
+    """Overload for from_json_like, refer to implementation."""
+    ...
+
+
+@overload
+def from_json_like(
+    tp: Type[T], value: Any, optional: Literal[False] = False,
+) -> T:  # pragma: no cover
+    """Overload for from_json_like, refer to implementation."""
+    ...
+
+
+def from_json_like(tp: Type[T], value: Any, optional: bool = False) -> Optional[T]:
     """Read a JSON-like object into a given schema type.
 
-    `schema_class` must be:
+    `tp` must be:
         - a JSON primitive type (int, float, str, bool or NoneType),
         - a List[T] of a JSON-compatible type, or
-        - a dataclass where every field is of a JSON-compatible type, or
-        - an Optional of a JSON-compatible type.
+        - a dataclass where every field is of a JSON-compatible type
 
     Args:
-        schema_class: A JSON-compatible type.
-        j: A JSON-compatible value to read.
+        tp: A JSON-compatible type.
+        value: A JSON-compatible value to read.
+        optional: Whether None should be accepted.
 
     Returns:
-        An object of the type given by `schema_class`.
+        An object of the type given by `tp`, or maybe None if `optional` is `True`.
     """
-    optional = is_optional_type(schema_class)
 
-    def resolve_type(schema_class):
-        (strict_type,) = (
-            [t for t in get_args(schema_class) if not is_none_type(t)]
-            if optional
-            else (schema_class,)
-        )
+    if value is None:
+        if not optional:
+            raise JSONConversionError(
+                'Cannot read None as a non optional value.', tp, value
+            )
 
-        if is_new_type(strict_type):
-            return original_type(strict_type)
+        return None
 
-        return strict_type
+    if get_origin(tp) is list:
+        if not isinstance(value, list):
+            raise JSONConversionError(
+                'Cannot read non-list value to a list type.', tp, value
+            )
+        return from_list(tp, value)  # type: ignore
 
-    strict_type = resolve_type(schema_class)
-
-    if strict_type is Any:
-        return j
-
-    strict_type_name = type_name(strict_type)
-    schema_class_name = (
-        strict_type_name if not optional else f'Optional[{strict_type_name}]'
-    )
-
-    if j is None:
-        if optional:
-            return None
-
-        raise JSONConversionError(
-            f'Cannot read None into non-optional type {schema_class_name}.',
-            schema_class,
-            j,
-        )
-
-    if isinstance(j, get_args(JSONPrimitives)):  # type: ignore
-        if isinstance(j, strict_type):
-            return j
-
-        if isinstance(j, get_args(Number)):  # type: ignore
-            if strict_type in get_args(Number):  # type: ignore
-                return schema_class(j)
-
-        raise JSONConversionError(
-            'Cannot read primitive value {j} into non-primitive type '
-            f'{schema_class_name}.',
-            schema_class,
-            j,
-        )
-
-    if isinstance(j, dict):
-        if is_dataclass(strict_type):
-            return from_dict(strict_type, j)
-
-        raise JSONConversionError(
-            f'Cannot read dictionary into non-dataclass type {schema_class_name}.',
-            schema_class,
-            j,
-        )
-
-    if isinstance(j, list):
-        if get_origin(strict_type) is list:
-            return from_list(strict_type, j)
-
-        raise JSONConversionError(
-            f'Failed to read list of types into non-list type {schema_class_name}.',
-            schema_class,
-            j,
-        )
-
-    raise JSONConversionError(
-        f'Failed to read value into type {schema_class_name}.', schema_class, j,
-    )
+    return convert_single(tp, value)
 
 
-def to_json(obj: Any) -> JSONLike:
+def to_json_like(obj: Any) -> JSONLike:
     """Serialize an object to a JSON-compatible representation.
 
     `obj` must be:
@@ -227,13 +204,13 @@ def to_json(obj: Any) -> JSONLike:
     if isinstance(obj, get_args(JSONPrimitives)):  # type: ignore
         return obj
     if isinstance(obj, dict):
-        return {k: to_json(v) for k, v in obj.items() if v is not None}
+        return {k: to_json_like(v) for k, v in obj.items() if v is not None}
     if is_dataclass(obj):
-        return {k: to_json(v) for k, v in asdict(obj).items() if v is not None}
+        return {k: to_json_like(v) for k, v in asdict(obj).items() if v is not None}
     if isinstance(obj, list):
-        return [to_json(v) for v in obj]
+        return [to_json_like(v) for v in obj]
     if isinstance(obj, Enum):
-        return to_json(obj.value)
+        return to_json_like(obj.value)
 
     obj_type = type(obj)
 

--- a/roboto/datautil.py
+++ b/roboto/datautil.py
@@ -1,20 +1,24 @@
 """Utilities from deserializing values as dataclasses."""
-import sys
 from dataclasses import Field, asdict, fields, is_dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast, overload
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    get_type_hints,
+    overload,
+)
 
 from typing_extensions import Protocol
 from typing_inspect import get_args, get_origin, is_optional_type
 
 from .error import RobotoError
-from .typing_util import (
-    evaluate_type,
-    is_new_type,
-    is_none_type,
-    original_type,
-    type_name,
-)
+from .typing_util import is_new_type, is_none_type, original_type, type_name
 
 T = TypeVar('T')
 
@@ -60,10 +64,8 @@ def field_type(cls: Type[T], field_name: str) -> type:
     Returns:
         The type of the requested field.
     """
-    as_dataclass = cast(Dataclass, cls)
 
-    tp = as_dataclass.__dataclass_fields__[field_name].type
-    return evaluate_type(tp, vars(sys.modules[cls.__module__]))
+    return get_type_hints(cls)[field_name]
 
 
 def from_list(list_type: Type[List[T]], v: List[JSONLike]) -> List[T]:

--- a/roboto/http_api.py
+++ b/roboto/http_api.py
@@ -10,7 +10,7 @@ from .api_types import FileDescription
 from .asks import Session
 from .asks.multipart import MultipartData
 from .asks.response_objects import Response
-from .datautil import from_json, to_json
+from .datautil import from_json_like, to_json_like
 from .error import BotAPIError
 
 
@@ -73,7 +73,7 @@ def validate_response(response: APIResponse) -> Any:
 async def _json_request(
     session: Session, method: HTTPMethod, api_method: str, body: Any = None
 ) -> Response:
-    return await session.request(method.value, path=api_method, json=to_json(body))
+    return await session.request(method.value, path=api_method, json=to_json_like(body))
 
 
 def _to_multipart_compatible(value: Any) -> Any:
@@ -114,7 +114,7 @@ async def _make_request(
 
     # We know that the server ensures the object will follow either protocol,
     # but mypy can't see that.
-    response: Any = from_json(AnyAPIResponse, content.json())
+    response: Any = from_json_like(AnyAPIResponse, content.json())
 
     return validate_response(response)
 
@@ -192,6 +192,6 @@ async def make_multipart_request_with_attachments(
         session, HTTPMethod.POST, api_method, body=fields,
     )
 
-    response: Any = from_json(AnyAPIResponse, content.json())
+    response: Any = from_json_like(AnyAPIResponse, content.json())
 
     return validate_response(response)

--- a/roboto/request_types.py
+++ b/roboto/request_types.py
@@ -18,7 +18,7 @@ from .api_types import (
     ReplyMarkup,
     UserID,
 )
-from .datautil import to_json
+from .datautil import to_json_like
 
 T = TypeVar('T')
 
@@ -29,7 +29,7 @@ class JSONSerialized(str, Generic[T]):
 
 def json_serialize(value: T) -> JSONSerialized[T]:
     """Serialize value to its strong-typed JSON string type."""
-    return cast(JSONSerialized[T], json.dumps(to_json(value)))
+    return cast(JSONSerialized[T], json.dumps(to_json_like(value)))
 
 
 def maybe_json_serialize(value: Optional[T]) -> Optional[JSONSerialized[T]]:

--- a/roboto/typing_util.py
+++ b/roboto/typing_util.py
@@ -1,6 +1,6 @@
 """Utilities for use with the `typing` module."""
 
-from typing import Any, Dict, Type, TypeVar, Union
+from typing import Type, TypeVar
 
 T = TypeVar('T')
 
@@ -39,16 +39,3 @@ def type_name(tp: Type[T]) -> str:
     if isinstance(tp, type):
         return tp.__name__
     return str(tp)
-
-
-TypeHint = Union[str, Type[T]]
-
-
-def evaluate_type(type_hint: TypeHint[T], context: Dict[str, Any]) -> Type[T]:
-    """Evaluate a type hint even if it is given as a string.
-
-    """
-    if not isinstance(type_hint, str):
-        return type_hint
-
-    return eval(type_hint, context)  # pylint: disable=eval-used

--- a/tests/test_datautil.py
+++ b/tests/test_datautil.py
@@ -7,12 +7,11 @@ from pytest import raises
 
 from roboto.datautil import (
     JSONConversionError,
-    field_type,
     from_dict,
-    from_json,
+    from_json_like,
     from_list,
     renames,
-    to_json,
+    to_json_like,
 )
 
 
@@ -29,23 +28,6 @@ def test_renames() -> None:
     assert renames(_Renamed) == {'x': 'b', 'y': 'c'}
 
 
-def test_field_type() -> None:
-    """Test that the `renames` function gathers the correct type
-
-    The type must be properly evaluated if defined as a string (or if delayed
-    evaluation is on)."""
-
-    @dataclass
-    class _DummyType:
-        a: int
-        b: 'str'
-        c: float
-        d: int = 5
-
-    assert field_type(_DummyType, 'a') is int
-    assert field_type(_DummyType, 'b') is str
-
-
 def test_from_dict() -> None:
     """Test `from_list` with different types."""
 
@@ -54,7 +36,7 @@ def test_from_dict() -> None:
         a: int
         b: str
 
-    assert from_dict(_SmallDummyType, {'a': 1, 'b': 'test'},) == _SmallDummyType(
+    assert from_dict(_SmallDummyType, {'a': 1, 'b': 'test'}) == _SmallDummyType(
         1, 'test'
     )
 
@@ -63,7 +45,7 @@ def test_from_dict() -> None:
         a: int
         from_: str = field(metadata={'rename': 'from'})
 
-    assert from_dict(_Renamed, {'a': 1, 'from': 'test'},) == _Renamed(1, 'test')
+    assert from_dict(_Renamed, {'a': 1, 'from': 'test'}) == _Renamed(1, 'test')
 
 
 def test_from_list() -> None:
@@ -85,35 +67,46 @@ def test_from_list() -> None:
     ]
 
 
-def test_from_json_with_any():
-    """Ensure `from_json` with `Any` as type simply returns the value."""
-    value = {'a': 1, 'b': 'text'}
+def test_from_json_like_with_any() -> None:
+    """Ensure `from_json_like` with `Any` as type simply returns the value."""
+    value = {'a': 1, 'b': {'a': 'text'}}
 
-    assert from_json(Any, value) is value
+    @dataclass
+    class _SmallDummyType:
+        a: int
+        b: Any
+
+    assert from_json_like(_SmallDummyType, value) == _SmallDummyType(
+        a=1, b={'a': 'text'},
+    )
 
 
-def test_from_json_optional_any() -> None:
-    """Ensure `from_json` understands Optional[Any]."""
-    value = {'a': 1, 'b': 'text'}
+def test_from_json_like_optional_any() -> None:
+    """Ensure `from_json_like` understands Optional[Any]."""
+    value = {'a': 1, 'b': None}
 
-    assert from_json(Optional[Any], value) is value  # type: ignore
-    assert from_json(Optional[Any], None) is None  # type: ignore
+    @dataclass
+    class _SmallDummyType:
+        a: int
+        b: Optional[Any] = None
+
+    assert from_json_like(_SmallDummyType, value) == _SmallDummyType(a=1)
 
 
-def test_from_json_with_optional() -> None:
-    """Ensure `from_json` accepts None with Optional and rejects otherwise."""
-    assert from_json(Optional[int], None) is None  # type: ignore
-    assert from_json(Optional[int], 1) == 1  # type: ignore
+def test_from_json_like_with_optional() -> None:
+    """Ensure `from_json_like` accepts None with Optional and rejects otherwise."""
+    assert from_json_like(int, None, optional=True) is None
+    assert from_json_like(int, 1, optional=True) == 1
 
     with raises(JSONConversionError):
-        from_json(int, None)
+        from_json_like(int, None)
 
 
-def test_from_json_with_numbers() -> None:
-    """Ensure `from_json` accepts ints and floats and properly converts."""
+def test_from_json_like_with_numbers() -> None:
+    """Ensure `from_json_like` accepts ints and floats and properly converts."""
 
     def _check(number_type, value, expected):
-        result = from_json(number_type, value)
+        result = from_json_like(number_type, value)
         assert result == expected
         assert isinstance(result, number_type)
 
@@ -123,14 +116,14 @@ def test_from_json_with_numbers() -> None:
     _check(float, 1.0, 1.0)
 
 
-def test_from_json_with_primitives() -> None:
-    """Ensure `from_json` returns the value itself with primitives.
+def test_from_json_like_with_primitives() -> None:
+    """Ensure `from_json_like` returns the value itself with primitives.
 
     On type mismatch, we expect failures.
     """
 
     def _check(primitive_type, value):
-        assert from_json(primitive_type, value) is value
+        assert from_json_like(primitive_type, value) is value
 
     _check(int, 1)
     _check(float, 1.0)
@@ -138,24 +131,24 @@ def test_from_json_with_primitives() -> None:
     _check(bool, True)
 
     with raises(JSONConversionError):
-        from_json(str, 1)
+        from_json_like(str, 1)
 
     with raises(JSONConversionError):
-        from_json(bool, 1)
+        from_json_like(bool, 1)
 
     with raises(JSONConversionError):
-        from_json(int, 'text')
+        from_json_like(int, 'text')
 
 
-def test_from_json_with_a_new_type() -> None:
-    """Ensure `from_json` works with `NewType`."""
+def test_from_json_like_with_a_new_type() -> None:
+    """Ensure `from_json_like` works with `NewType`."""
     UserID = NewType('UserID', int)
 
-    assert from_json(UserID, 1) == UserID(1)
+    assert from_json_like(UserID, 1) == UserID(1)
 
 
-def test_from_json_with_dict():
-    """Ensure `from_json` can read a dict into a dataclass.
+def test_from_json_like_with_dict() -> None:
+    """Ensure `from_json_like` can read a dict into a dataclass.
 
     Should fail if the schema class is not a compatible dataclass.
     """
@@ -165,12 +158,12 @@ def test_from_json_with_dict():
         a: int
         b: str = 'test'
 
-    assert from_json(_Test, {'a': 1, 'b': 'other_text'}) == _Test(1, 'other_text')
+    assert from_json_like(_Test, {'a': 1, 'b': 'other_text'}) == _Test(1, 'other_text')
 
-    assert from_json(_Test, {'a': 1}) == _Test(1, 'test')
+    assert from_json_like(_Test, {'a': 1}) == _Test(1, 'test')
 
     with raises(JSONConversionError):
-        from_json(int, {'a': 1})
+        from_json_like(int, {'a': 1})
 
     class _NotADataclass:
         def __init__(self, a: int, b: str = 'test'):
@@ -178,22 +171,22 @@ def test_from_json_with_dict():
             self.b = b
 
     with raises(JSONConversionError):
-        from_json(_NotADataclass, {'a': 1})
+        from_json_like(_NotADataclass, {'a': 1})
 
 
-def test_from_json_with_list() -> None:
-    """Ensure `from_json` can read a list of values.
+def test_from_json_like_with_list() -> None:
+    """Ensure `from_json_like` can read a list of values.
 
     Should fail if the schema class is not a compatible dataclass.
     """
-    assert from_json(List[int], [1, 2, 3]) == [1, 2, 3]
+    assert from_json_like(List[int], [1, 2, 3]) == [1, 2, 3]
 
     @dataclass
     class _SmallDummyType:
         a: int
         b: str
 
-    assert from_json(
+    assert from_json_like(
         List[_SmallDummyType],
         [{'a': 1, 'b': 'test'}, {'a': 2, 'b': 'test2'}, {'a': 42, 'b': 'test'}],
     ) == [
@@ -203,92 +196,102 @@ def test_from_json_with_list() -> None:
     ]
 
     with raises(JSONConversionError):
-        assert from_json(int, [1, 2, 3],)
+        assert from_json_like(int, [1, 2, 3])
 
 
-def test_from_json_with_optional_list() -> None:
-    """Ensure `from_json` can read an optional list of values."""
+def test_from_json_like_with_optional_list() -> None:
+    """Ensure `from_json_like` can read an optional list of values."""
 
-    assert from_json(Optional[List[int]], None) is None  # type: ignore
-    assert from_json(Optional[List[int]], [1, 2, 3]) == [1, 2, 3]  # type: ignore
+    assert from_json_like(List[int], None, optional=True) is None
+    assert from_json_like(List[int], [1, 2, 3], optional=True) == [1, 2, 3]
 
 
-def test_from_json_incompatible_type() -> None:
-    """Ensure from_json fails in an expected way if value is unsupported."""
+def test_from_json_like_incompatible_type() -> None:
+    """Ensure from_json_like fails in an expected way if value is unsupported."""
     with raises(JSONConversionError):
-        # To be fair, mypy won't let you.
-        assert from_json(  # type: ignore
-            List[int], {1, 2, 3},
+        assert from_json_like(List[int], {1, 2, 3})
+
+    @dataclass
+    class _SmallDummyType:
+        a: int
+        b: str
+
+    with raises(JSONConversionError):
+        assert from_json_like(  # type: ignore
+            _SmallDummyType, 1,
         )
 
 
-def test_to_json_primitive_types() -> None:
-    """Ensure to_json doesn't change primitive types."""
-    assert to_json(1) == 1
-    assert to_json(1.0) == 1.0
-    assert to_json('text') == 'text'
-    assert to_json(True)
+def test_to_json_like_primitive_types() -> None:
+    """Ensure to_json_like doesn't change primitive types."""
+    assert to_json_like(1) == 1
+    assert to_json_like(1.0) == 1.0
+    assert to_json_like('text') == 'text'
+    assert to_json_like(True)
 
 
-def test_to_json_dataclass_type() -> None:
-    """Ensure to_json doesn't change primitive types."""
+def test_to_json_like_dataclass_type() -> None:
+    """Ensure to_json_like doesn't change primitive types."""
 
     @dataclass
     class _Serializable:
         x: int
         y: str
 
-    assert to_json(_Serializable(1, 'bla')) == {'x': 1, 'y': 'bla'}
+    assert to_json_like(_Serializable(1, 'bla')) == {'x': 1, 'y': 'bla'}
 
     @dataclass
     class _Nested:
         x: int
         y: _Serializable
 
-    assert to_json(_Nested(1, _Serializable(1, 'bla'))) == {
+    assert to_json_like(_Nested(1, _Serializable(1, 'bla'))) == {
         'x': 1,
         'y': {'x': 1, 'y': 'bla'},
     }
 
 
-def test_to_json_list_type() -> None:
-    """Ensure to_json doesn't change primitive types."""
+def test_to_json_like_list_type() -> None:
+    """Ensure to_json_like doesn't change primitive types."""
 
     @dataclass
     class _Serializable:
         x: int
         y: str
 
-    assert to_json([_Serializable(1, 'text'), _Serializable(2, 'other')]) == (
+    assert to_json_like([_Serializable(1, 'text'), _Serializable(2, 'other')]) == (
         [{'x': 1, 'y': 'text'}, {'x': 2, 'y': 'other'}]
     )
 
 
-def test_to_json_enum_type() -> None:
-    """Ensure to_json supports Enum types."""
+def test_to_json_like_enum_type() -> None:
+    """Ensure to_json_like supports Enum types."""
 
     class _MyEnum(Enum):
         A = 1
         B = 2
 
-    assert to_json(_MyEnum.A) == 1
+    assert to_json_like(_MyEnum.A) == 1
 
     class _StrEnum(Enum):
         A = 'text'
         B = 'other'
 
-    assert to_json(_StrEnum.A) == 'text'
+    assert to_json_like(_StrEnum.A) == 'text'
 
     @dataclass
     class _HasEnumMembers:
         x: _MyEnum
         y: _StrEnum
 
-    assert to_json(_HasEnumMembers(_MyEnum.B, _StrEnum.B)) == {'x': 2, 'y': 'other'}
+    assert to_json_like(_HasEnumMembers(_MyEnum.B, _StrEnum.B)) == {
+        'x': 2,
+        'y': 'other',
+    }
 
 
-def test_to_json_unsupported_type() -> None:
-    """Ensure to_json raises with unsupported object."""
+def test_to_json_like_unsupported_type() -> None:
+    """Ensure to_json_like raises with unsupported object."""
 
     class _NotADataclass:
         def __init__(self, a: int, b: str):
@@ -296,4 +299,4 @@ def test_to_json_unsupported_type() -> None:
             self.b = b
 
     with raises(JSONConversionError):
-        to_json(_NotADataclass(1, 'text'))
+        to_json_like(_NotADataclass(1, 'text'))

--- a/tests/test_datautil.py
+++ b/tests/test_datautil.py
@@ -209,7 +209,8 @@ def test_from_json_like_with_optional_list() -> None:
 def test_from_json_like_incompatible_type() -> None:
     """Ensure from_json_like fails in an expected way if value is unsupported."""
     with raises(JSONConversionError):
-        assert from_json_like(List[int], {1, 2, 3})
+        # mypy wouldn't let this happen though
+        assert from_json_like(List[int], {1, 2, 3})  # type: ignore
 
     @dataclass
     class _SmallDummyType:


### PR DESCRIPTION
This is an almost complete rewrite of the `from_json` part of `datautil.py`. Some type-checking has been relaxed (not much) and the testable/callable interface does not expect non-reified types to be passed through it anymore (see python/mypy#8941).